### PR TITLE
Enhancement : New Endpoint to Retrieve Combined Lost and Found Items

### DIFF
--- a/backend-go/internal/controller/lost.go
+++ b/backend-go/internal/controller/lost.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sort"
 	"strconv"
+	"time"
 
 	"github.com/LambdaIITH/Dashboard/backend/config"
 	lost "github.com/LambdaIITH/Dashboard/backend/internal/db"
@@ -130,6 +132,121 @@ func GetAllItemsHandler(c *gin.Context) {
 		response = append(response, itemData)
 	}
 
+	c.JSON(http.StatusOK, response)
+}
+
+/*
+GetCombinedAllItemsHandler fetches all the lost and found items and returns them as a JSON response ordered by creation time.
+*/
+func GetCombinedAllItemsHandler(c *gin.Context) {
+
+	maxLimit := 100
+	if limitStr := c.Query("max_limit"); limitStr != "" {
+		if limit, err := strconv.Atoi(limitStr); err == nil {
+			maxLimit = limit
+		}
+	}
+
+	//Step 1: Fetching lost items AND found items
+	lostItems, err := lost.GetAllLostItems(c)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch items"})
+		fmt.Println(err)
+		return
+	}
+	if len(lostItems) > maxLimit {
+		lostItems = lostItems[:maxLimit]
+	}
+
+	foundItems, err := lost.GetAllFoundItems(c)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch items"})
+		return
+	}
+
+	if len(foundItems) > maxLimit {
+		foundItems = foundItems[:maxLimit]
+	}
+
+	//Step 2: Fetching images for all lost items AND found items
+	lostRows, err := config.DB.Query(c, "SELECT item_id, image_url FROM lost_images")
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch images"})
+		return
+	}
+	defer lostRows.Close()
+
+	foundRows, err := config.DB.Query(c, "SELECT item_id, image_url FROM found_images")
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch images"})
+		return
+	}
+	defer foundRows.Close()
+
+	//Step 3: Organize the image urls by item ID
+	imageDict := make(map[int][]string)
+	for lostRows.Next() {
+		var img schema.ImageURI
+		if err := lostRows.Scan(&img.ItemID, &img.ImageURL); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to scan images"})
+			return
+		}
+		imageDict[img.ItemID] = append(imageDict[img.ItemID], img.ImageURL)
+	}
+
+	for foundRows.Next() {
+		var img schema.ImageURI
+		if err := foundRows.Scan(&img.ItemID, &img.ImageURL); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to scan images"})
+			return
+		}
+		imageDict[img.ItemID] = append(imageDict[img.ItemID], img.ImageURL)
+	}
+
+	response := make([]map[string]any, 0, len(lostItems)+len(foundItems))
+
+	for _, item := range lostItems {
+		images := imageDict[item.ID]
+		if images == nil {
+			images = []string{}
+		}
+
+		itemData := map[string]any{
+			"id":         item.ID,
+			"name":       item.ItemName,
+			"images":     images,
+			"created_at": item.CreatedAt.Format(time.RFC3339),
+			"type":       "lost",
+		}
+		response = append(response, itemData)
+	}
+	for _, item := range foundItems {
+		images := imageDict[item.ID]
+		if images == nil {
+			images = []string{}
+		}
+
+		itemData := map[string]any{
+			"id":         item.ID,
+			"name":       item.ItemName,
+			"images":     images,
+			"created_at": item.CreatedAt.Format(time.RFC3339),
+			"type":       "found",
+		}
+		response = append(response, itemData)
+	}
+
+	sort.Slice(response, func(i, j int) bool {
+		t1, _ := time.Parse(time.RFC3339, response[i]["created_at"].(string))
+		t2, _ := time.Parse(time.RFC3339, response[j]["created_at"].(string))
+		return t1.After(t2) //newest first
+	})
+
+	if len(response) > maxLimit {
+		response = response[:maxLimit]
+	}
+
+	// Step 4: Return the response
 	c.JSON(http.StatusOK, response)
 }
 

--- a/backend-go/internal/controller/lost.go
+++ b/backend-go/internal/controller/lost.go
@@ -151,7 +151,7 @@ func GetCombinedAllItemsHandler(c *gin.Context) {
 	lostItems, err := lost.GetAllLostItems(c)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch items"})
-		fmt.Println(err)
+
 		return
 	}
 
@@ -164,45 +164,11 @@ func GetCombinedAllItemsHandler(c *gin.Context) {
 
 
 
-	//Step 2: Fetching images for all lost items AND found items
-	lostRows, err := config.DB.Query(c, "SELECT item_id, image_url FROM lost_images")
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch images"})
-		return
-	}
-	defer lostRows.Close()
-
-	foundRows, err := config.DB.Query(c, "SELECT item_id, image_url FROM found_images")
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch images"})
-		return
-	}
-	defer foundRows.Close()
-
-	//Step 3: Organize the image urls by item ID
-	imageDict := make(map[int][]string)
-	for lostRows.Next() {
-		var img schema.ImageURI
-		if err := lostRows.Scan(&img.ItemID, &img.ImageURL); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to scan images"})
-			return
-		}
-		imageDict[img.ItemID] = append(imageDict[img.ItemID], img.ImageURL)
-	}
-
-	for foundRows.Next() {
-		var img schema.ImageURI
-		if err := foundRows.Scan(&img.ItemID, &img.ImageURL); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to scan images"})
-			return
-		}
-		imageDict[img.ItemID] = append(imageDict[img.ItemID], img.ImageURL)
-	}
-
+	//Step 2: Initialize response slice
 	response := make([]map[string]any, 0, len(lostItems)+len(foundItems))
 
 	for _, item := range lostItems {
-		images := imageDict[item.ID]
+		images := item.Images
 		if images == nil {
 			images = []string{}
 		}
@@ -211,13 +177,13 @@ func GetCombinedAllItemsHandler(c *gin.Context) {
 			"id":         item.ID,
 			"name":       item.ItemName,
 			"images":     images,
-			"created_at": item.CreatedAt.Format(time.RFC3339),
+			"created_at": item.CreatedAt,
 			"type":       "lost",
 		}
 		response = append(response, itemData)
 	}
 	for _, item := range foundItems {
-		images := imageDict[item.ID]
+		images := item.Images
 		if images == nil {
 			images = []string{}
 		}
@@ -226,27 +192,15 @@ func GetCombinedAllItemsHandler(c *gin.Context) {
 			"id":         item.ID,
 			"name":       item.ItemName,
 			"images":     images,
-			"created_at": item.CreatedAt.Format(time.RFC3339),
+			"created_at": item.CreatedAt,
 			"type":       "found",
 		}
 		response = append(response, itemData)
 	}
 
 	sort.Slice(response, func(i, j int) bool {
-		t1, err1 := time.Parse(time.RFC3339, response[i]["created_at"].(string))
-		t2, err2 := time.Parse(time.RFC3339, response[j]["created_at"].(string))
-		if err1 != nil && err2 != nil {
-			// Both times invalid, keep original order
-			return false
-		}
-		if err1 != nil {
-			// i is invalid, j is valid: j comes first (i is "older")
-			return false
-		}
-		if err2 != nil {
-			// j is invalid, i is valid: i comes first (i is "newer")
-			return true
-		}
+		t1 := response[i]["created_at"].(time.Time)
+		t2 := response[j]["created_at"].(time.Time)
 		return t1.After(t2) // newest first
 	})
 

--- a/backend-go/internal/controller/lost.go
+++ b/backend-go/internal/controller/lost.go
@@ -154,9 +154,7 @@ func GetCombinedAllItemsHandler(c *gin.Context) {
 		fmt.Println(err)
 		return
 	}
-	if len(lostItems) > maxLimit {
-		lostItems = lostItems[:maxLimit]
-	}
+
 
 	foundItems, err := lost.GetAllFoundItems(c)
 	if err != nil {
@@ -164,9 +162,7 @@ func GetCombinedAllItemsHandler(c *gin.Context) {
 		return
 	}
 
-	if len(foundItems) > maxLimit {
-		foundItems = foundItems[:maxLimit]
-	}
+
 
 	//Step 2: Fetching images for all lost items AND found items
 	lostRows, err := config.DB.Query(c, "SELECT item_id, image_url FROM lost_images")
@@ -237,9 +233,21 @@ func GetCombinedAllItemsHandler(c *gin.Context) {
 	}
 
 	sort.Slice(response, func(i, j int) bool {
-		t1, _ := time.Parse(time.RFC3339, response[i]["created_at"].(string))
-		t2, _ := time.Parse(time.RFC3339, response[j]["created_at"].(string))
-		return t1.After(t2) //newest first
+		t1, err1 := time.Parse(time.RFC3339, response[i]["created_at"].(string))
+		t2, err2 := time.Parse(time.RFC3339, response[j]["created_at"].(string))
+		if err1 != nil && err2 != nil {
+			// Both times invalid, keep original order
+			return false
+		}
+		if err1 != nil {
+			// i is invalid, j is valid: j comes first (i is "older")
+			return false
+		}
+		if err2 != nil {
+			// j is invalid, i is valid: i comes first (i is "newer")
+			return true
+		}
+		return t1.After(t2) // newest first
 	})
 
 	if len(response) > maxLimit {

--- a/backend-go/internal/router/routes.go
+++ b/backend-go/internal/router/routes.go
@@ -80,7 +80,7 @@ func SetupRoutes(router *gin.Engine) {
 	//Group routes for lost-found items
 	lostFoundGroup := router.Group("/lost_found")
 	{
-		lostFoundGroup.GET("/all", controller.GetCombinedAllItemsHandler) //optional parameter max_limit
+		lostFoundGroup.GET("/", controller.GetCombinedAllItemsHandler) //optional parameter max_limit
 	}
 
 	//Group routes for timetable/calendar

--- a/backend-go/internal/router/routes.go
+++ b/backend-go/internal/router/routes.go
@@ -77,6 +77,12 @@ func SetupRoutes(router *gin.Engine) {
 		foundGroup.GET("/search", controller.SearchFoundItemHandler)
 	}
 
+	//Group routes for lost-found items
+	lostFoundGroup := router.Group("/lost_found")
+	{
+		lostFoundGroup.GET("/all", controller.GetCombinedAllItemsHandler) //optional parameter max_limit
+	}
+
 	//Group routes for timetable/calendar
 	timetableGroup := router.Group("/schedule")
 	{


### PR DESCRIPTION
Fixes #15 

Added a new API endpoint `/lost_found/all` that returns both lost and found items in a single response, sorted based on creation time. It has an optional query parameter `max_limit` that controls the numbers of items returned.